### PR TITLE
Public folders and prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ When deploying the application, the following environment variables can be set:
 | AZURE_AD_CLIENT_ID                |                                | Azure AD Application (client) ID (see: [Quickstart AD](https://learn.microsoft.com/en-us/azure/active-directory/develop/))                |
 | AZURE_AD_TENANT_ID                |                                | Azure AD Directory (tenant) ID                                                                                                            |
 | AZURE_AD_CLIENT_SECRET            |                                | Azure AD Client secret value (Certificates & secrets > Client Secrets > New Client Secret > Value)                                        |
+| PROMPT_SHARING_ENABLED            | `false`                        | Enable prompt sharing between users. Only admin users are allowed to modify public folders. Add admins by setting db collection field `users.role` to `admin` for each individual user.   |
+
 
 If you do not provide an OpenAI API key with `OPENAI_API_KEY`, users will have to provide their own key.
 If you don't have an OpenAI API key, you can get one [here](https://platform.openai.com/account/api-keys).

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -48,6 +48,7 @@ export const Chat = memo(() => {
       modelError,
       loading,
       prompts,
+      publicPrompts,
       settings,
     },
   } = useContext(HomeContext);
@@ -272,6 +273,7 @@ export const Chat = memo(() => {
                           conversation={selectedConversation}
                           systemPrompt={systemPrompt}
                           prompts={prompts}
+                          publicPrompts={publicPrompts}
                           onChangePrompt={(prompt) => setSystemPrompt(prompt)}
                         />
 

--- a/components/Chat/PromptList.tsx
+++ b/components/Chat/PromptList.tsx
@@ -1,9 +1,11 @@
 import { FC, MutableRefObject } from 'react';
 
 import { Prompt } from '@/types/prompt';
+import { IconShare } from '@tabler/icons-react';
 
 interface Props {
   prompts: Prompt[];
+  publicPrompts: Prompt[];
   activePromptIndex: number;
   onSelect: () => void;
   onMouseOver: (index: number) => void;
@@ -12,34 +14,48 @@ interface Props {
 
 export const PromptList: FC<Props> = ({
   prompts,
+  publicPrompts,
   activePromptIndex,
   onSelect,
   onMouseOver,
   promptListRef,
 }) => {
-  return (
-    <ul
-      ref={promptListRef}
-      className="z-10 max-h-52 w-full overflow-scroll rounded border border-black/10 bg-white shadow-[0_0_10px_rgba(0,0,0,0.10)] dark:border-neutral-500 dark:bg-[#343541] dark:text-white dark:shadow-[0_0_15px_rgba(0,0,0,0.10)]"
-    >
-      {prompts.map((prompt, index) => (
+  const promptItems = (prompts: Prompt[], isPublic: boolean, startIndex: number) => {
+    return (
+      prompts.map((prompt, index) => (
         <li
           key={prompt.id}
           className={`${
-            index === activePromptIndex
+           startIndex + index === activePromptIndex
               ? 'bg-gray-200 dark:bg-[#202123] dark:text-black'
               : ''
-          } cursor-pointer px-3 py-2 text-sm text-black dark:text-white`}
+          } cursor-pointer px-3 py-2 text-sm text-black dark:text-white flex justify-between`}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
             onSelect();
           }}
-          onMouseEnter={() => onMouseOver(index)}
+          onMouseEnter={() => onMouseOver(startIndex + index)}
         >
           {prompt.name}
+          {isPublic && (
+            <IconShare size={18} />
+          )}
         </li>
-      ))}
+      ))
+    )
+  }
+  return (
+    <ul
+      ref={promptListRef}
+      className="z-10 max-h-52 w-full overflow-scroll rounded border border-black/10 bg-white shadow-[0_0_10px_rgba(0,0,0,0.10)] dark:border-neutral-500 dark:bg-[#343541] dark:text-white dark:shadow-[0_0_15px_rgba(0,0,0,0.10)]"
+    >
+      {
+        [
+          ...promptItems(prompts, false, 0),
+          ...promptItems(publicPrompts, true, prompts.length)
+        ]
+      }
     </ul>
   );
 };

--- a/components/Chatbar/Chatbar.tsx
+++ b/components/Chatbar/Chatbar.tsx
@@ -220,6 +220,8 @@ export const Chatbar = () => {
         folderComponent={<ChatFolders searchTerm={searchTerm} />}
         items={filteredConversations}
         searchTerm={searchTerm}
+        searchPlaceholder={t('Search conversations...')}
+        noItemsPlaceholder={t('No conversations.')}
         handleSearchTerm={(searchTerm: string) =>
           chatDispatch({ field: 'searchTerm', value: searchTerm })
         }

--- a/components/Chatbar/components/ChatFolders.tsx
+++ b/components/Chatbar/components/ChatFolders.tsx
@@ -9,6 +9,7 @@ import HomeContext from '@/pages/api/home/home.context';
 import Folder from '@/components/Folder';
 
 import { ConversationComponent } from './Conversation';
+import useFolders from '@/hooks/useFolders';
 
 interface Props {
   searchTerm: string;
@@ -19,6 +20,7 @@ export const ChatFolders = ({ searchTerm }: Props) => {
     state: { folders, conversations },
   } = useContext(HomeContext);
   const [_, conversationsAction] = useConversations();
+  const [_f, foldersAction] = useFolders();
 
   const handleDrop = (e: any, folder: FolderInterface) => {
     if (e.dataTransfer) {
@@ -28,6 +30,14 @@ export const ChatFolders = ({ searchTerm }: Props) => {
         value: folder.id,
       });
     }
+  };
+
+  const handleEditFolder = (folder: FolderInterface) => {
+    foldersAction.update(folder);
+  };
+
+  const handleDeleteFolder = (folder: FolderInterface) => {
+    foldersAction.remove(folder.id);
   };
 
   const ChatFolders = (currentFolder: FolderInterface) => {
@@ -59,6 +69,8 @@ export const ChatFolders = ({ searchTerm }: Props) => {
             currentFolder={folder}
             handleDrop={handleDrop}
             folderComponent={ChatFolders(folder)}
+            handleEditFolder={handleEditFolder}
+            handleDeleteFolder={handleDeleteFolder}
           />
         ))}
     </div>

--- a/components/Input/InputText.tsx
+++ b/components/Input/InputText.tsx
@@ -2,11 +2,13 @@ import { useCallback, useState } from 'react';
 
 interface Props {
   inputRef?: React.RefObject<HTMLInputElement>;
+  isEditable?: boolean
 }
 export const InputText = ({
   inputRef,
   onChange,
   onKeyDown,
+  isEditable = true,
   ...restProps
 }: Props & React.InputHTMLAttributes<HTMLInputElement>) => {
   const [isTyping, setIsTyping] = useState<boolean>(false);
@@ -51,6 +53,7 @@ export const InputText = ({
           setEndComposing(true);
         }
       }}
+      readOnly={!isEditable}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       {...restProps}

--- a/components/Input/Textarea.tsx
+++ b/components/Input/Textarea.tsx
@@ -3,6 +3,7 @@ import React, { DetailedHTMLProps, useCallback, useState } from 'react';
 interface Props {
   textareaRef?: React.RefObject<HTMLTextAreaElement>;
   rows?: number;
+  isEditable?: boolean;
 }
 
 export const Textarea = ({
@@ -10,6 +11,7 @@ export const Textarea = ({
   rows,
   onChange,
   onKeyDown,
+  isEditable = true,
   ...restProps
 }: Props &
   DetailedHTMLProps<
@@ -55,6 +57,7 @@ export const Textarea = ({
           setEndComposing(true);
         }
       }}
+      readOnly={!isEditable}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       {...restProps}

--- a/components/Promptbar/PromptBar.context.tsx
+++ b/components/Promptbar/PromptBar.context.tsx
@@ -5,6 +5,7 @@ import { ActionType } from '@/hooks/useCreateReducer';
 import { Prompt } from '@/types/prompt';
 
 import { PromptbarInitialState } from './Promptbar.state';
+import { FolderInterface } from '@/types/folder';
 
 export interface PromptbarContextProps {
   state: PromptbarInitialState;
@@ -12,6 +13,15 @@ export interface PromptbarContextProps {
   handleCreatePrompt: () => void;
   handleDeletePrompt: (prompt: Prompt) => void;
   handleUpdatePrompt: (prompt: Prompt) => void;
+  handleCreatePublicPrompt: (prompt: Prompt) => void;
+  handleDeletePublicPrompt: (prompt: Prompt) => void;
+  handleUpdatePublicPrompt: (prompt: Prompt) => void;
+  handleCreateFolder: () => void;
+  handleEditFolder: (folder: FolderInterface) => void;
+  handleDeleteFolder: (folder: FolderInterface) => void;
+  handleCreatePublicFolder: () => void;
+  handleEditPublicFolder: (folder: FolderInterface) => void;
+  handleDeletePublicFolder: (folder: FolderInterface) => void;
 }
 
 const PromptbarContext = createContext<PromptbarContextProps>(undefined!);

--- a/components/Promptbar/Promptbar.state.tsx
+++ b/components/Promptbar/Promptbar.state.tsx
@@ -3,9 +3,11 @@ import { Prompt } from '@/types/prompt';
 export interface PromptbarInitialState {
   searchTerm: string;
   filteredPrompts: Prompt[];
+  filteredPublicPrompts: Prompt[];
 }
 
 export const initialState: PromptbarInitialState = {
   searchTerm: '',
   filteredPrompts: [],
+  filteredPublicPrompts: [],
 };

--- a/components/Promptbar/components/Prompt.tsx
+++ b/components/Promptbar/components/Prompt.tsx
@@ -2,6 +2,7 @@ import {
   IconBulbFilled,
   IconCheck,
   IconTrash,
+  IconCloudUpload,
   IconX,
 } from '@tabler/icons-react';
 import {
@@ -18,25 +19,40 @@ import SidebarActionButton from '@/components/Buttons/SidebarActionButton';
 
 import PromptbarContext from '../PromptBar.context';
 import { PromptModal } from './PromptModal';
+import { PromptShareModal } from './PromptShareModal';
+import usePublicFolders from '@/hooks/usePublicFolders';
 
 interface Props {
   prompt: Prompt;
+  isEditable?: boolean;
+  isRemovable?: boolean;
+  isShareable?: boolean;
+  isDraggable?: boolean;
+  handleUpdatePrompt(prompt: Prompt): void;
+  handleDeletePrompt(prompt: Prompt): void;
+  handlePublishPrompt(prompt: Prompt): void;
 }
 
-export const PromptComponent = ({ prompt }: Props) => {
+export const PromptComponent = ({ prompt, isEditable = true, isRemovable = true, isShareable = true, isDraggable = true, handleUpdatePrompt, handleDeletePrompt, handlePublishPrompt }: Props) => {
   const {
     dispatch: promptDispatch,
-    handleUpdatePrompt,
-    handleDeletePrompt,
   } = useContext(PromptbarContext);
 
+  const [publicFolders] = usePublicFolders();
   const [showModal, setShowModal] = useState<boolean>(false);
+  const [showShareModal, setShowShareModal] = useState<boolean>(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState('');
+  const [actionButtonCount] = useState([isShareable, isRemovable].filter((bool) => bool).length);
 
   const handleUpdate = (prompt: Prompt) => {
     handleUpdatePrompt(prompt);
+    promptDispatch({ field: 'searchTerm', value: '' });
+  };
+
+  const handlePublish = (prompt: Prompt) => {
+    handlePublishPrompt(prompt);
     promptDispatch({ field: 'searchTerm', value: '' });
   };
 
@@ -79,12 +95,12 @@ export const PromptComponent = ({ prompt }: Props) => {
     <div className="relative flex items-center">
       <button
         className="flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-sm transition-colors duration-200 hover:bg-[#343541]/90"
-        draggable="true"
+        draggable={isDraggable}
         onClick={(e) => {
           e.stopPropagation();
           setShowModal(true);
         }}
-        onDragStart={(e) => handleDragStart(e, prompt)}
+        onDragStart={isDraggable ? (e) => handleDragStart(e, prompt) : undefined}
         onMouseLeave={() => {
           setIsDeleting(false);
           setIsRenaming(false);
@@ -93,7 +109,8 @@ export const PromptComponent = ({ prompt }: Props) => {
       >
         <IconBulbFilled size={18} />
 
-        <div className="relative max-h-5 flex-1 overflow-hidden text-ellipsis whitespace-nowrap break-all pr-4 text-left text-[12.5px] leading-3">
+        <div className="relative max-h-5 flex-1 overflow-hidden text-ellipsis whitespace-nowrap break-all text-left text-[12.5px] leading-3"
+          style={{ paddingRight: actionButtonCount * 1.5 + "rem" }}>
           {prompt.name}
         </div>
       </button>
@@ -112,9 +129,16 @@ export const PromptComponent = ({ prompt }: Props) => {
 
       {!isDeleting && !isRenaming && (
         <div className="absolute right-1 z-10 flex text-gray-300">
-          <SidebarActionButton handleClick={handleOpenDeleteModal}>
-            <IconTrash size={18} />
-          </SidebarActionButton>
+          {isShareable &&
+            <SidebarActionButton handleClick={() => setShowShareModal(true)}>
+              <IconCloudUpload size={18} />
+            </SidebarActionButton>
+          }
+          {isRemovable &&
+            <SidebarActionButton handleClick={handleOpenDeleteModal}>
+              <IconTrash size={18} />
+            </SidebarActionButton>
+          }
         </div>
       )}
 
@@ -124,6 +148,17 @@ export const PromptComponent = ({ prompt }: Props) => {
           prompt={prompt}
           onClose={() => setShowModal(false)}
           onUpdatePrompt={handleUpdate}
+          isEditable={isEditable}
+        />
+      )}
+
+      {showShareModal && (
+        <PromptShareModal
+          open={showShareModal}
+          prompt={prompt}
+          folders={publicFolders}
+          onClose={() => setShowShareModal(false)}
+          onPublishPrompt={handlePublish}
         />
       )}
     </div>

--- a/components/Promptbar/components/PromptFolders.tsx
+++ b/components/Promptbar/components/PromptFolders.tsx
@@ -1,6 +1,7 @@
 import { useContext } from 'react';
 
 import { FolderInterface } from '@/types/folder';
+import { Prompt } from '@/types/prompt';
 
 import HomeContext from '@/pages/api/home/home.context';
 
@@ -8,16 +9,34 @@ import Folder from '@/components/Folder';
 import { PromptComponent } from '@/components/Promptbar/components/Prompt';
 
 import PromptbarContext from '../PromptBar.context';
+import { useSession } from 'next-auth/react';
+import { useTranslation } from 'react-i18next';
+import { UserRole } from '@/types/user';
 
 export const PromptFolders = () => {
+  const { t } = useTranslation('promptbar');
+
   const {
-    state: { folders },
+    state: { folders, publicFolders, promptSharingEnabled },
   } = useContext(HomeContext);
 
   const {
-    state: { searchTerm, filteredPrompts },
+    state: { searchTerm, filteredPrompts, filteredPublicPrompts },
     handleUpdatePrompt,
+    handleDeletePrompt,
+    handleCreatePublicPrompt,
+    handleUpdatePublicPrompt,
+    handleDeletePublicPrompt,
+    handleCreateFolder,
+    handleEditFolder,
+    handleDeleteFolder,
+    handleCreatePublicFolder,
+    handleEditPublicFolder,
+    handleDeletePublicFolder
   } = useContext(PromptbarContext);
+
+  const session = useSession()
+  const isAdminUser: boolean = session.data?.user?.role === UserRole.ADMIN;
 
   const handleDrop = (e: any, folder: FolderInterface) => {
     if (e.dataTransfer) {
@@ -32,33 +51,84 @@ export const PromptFolders = () => {
     }
   };
 
-  const PromptFolders = (currentFolder: FolderInterface) =>
-    filteredPrompts
-      .filter((p) => p.folderId)
-      .map((prompt, index) => {
-        if (prompt.folderId === currentFolder.id) {
-          return (
-            <div key={index} className="ml-5 gap-2 border-l pl-2">
-              <PromptComponent prompt={prompt} />
-            </div>
-          );
+  const PromptFolders = (prompts: Prompt[], folders: FolderInterface[], handleUpdatePrompt: any, handleDeletePrompt: any, handleCreatePublicPrompt: any,
+    handleAddItem: any, handleEditFolder?: any, handleDeleteFolder?: any, handleDrop?: any, isShareable = true, isDraggable = true) => {
+    return ([
+      <div className="flex w-full flex-col" key="0">
+        {
+          (folders
+            .filter((folder) => folder.type === 'prompt')
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((folder, index) => (
+              <Folder
+                key={folder.id}
+                searchTerm={searchTerm}
+                currentFolder={folder}
+                handleDrop={handleDrop || undefined}
+                folderComponent={
+                  prompts
+                    .filter((p) => p.folderId)
+                    .map((prompt, index) => {
+                      if (prompt.folderId === folder.id) {
+                        const canEditPrompt = isAdminUser || prompt.userId === session.data?.user?._id;
+                        return (
+                          <div key={prompt.id} className="ml-5 gap-2 border-l pl-2">
+                            <PromptComponent
+                              prompt={prompt}
+                              isEditable={canEditPrompt}
+                              isRemovable={canEditPrompt}
+                              isShareable={isShareable}
+                              isDraggable={isDraggable}
+                              handleUpdatePrompt={handleUpdatePrompt}
+                              handleDeletePrompt={handleDeletePrompt}
+                              handlePublishPrompt={handleCreatePublicPrompt}
+                            />
+                          </div>
+                        );
+                      }
+                    })
+                }
+                handleAddItem={handleAddItem}
+                handleEditFolder={handleEditFolder}
+                handleDeleteFolder={handleDeleteFolder}
+              />
+            )))
         }
-      });
+      </div>]
+    )
+  }
 
   return (
     <div className="flex w-full flex-col pt-2">
-      {folders
-        .filter((folder) => folder.type === 'prompt')
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((folder, index) => (
+      {!promptSharingEnabled && PromptFolders(filteredPrompts, folders, handleUpdatePrompt, handleDeletePrompt, handleCreatePublicPrompt,
+        undefined, handleEditFolder, handleDeleteFolder, handleDrop, false, true)}
+      {promptSharingEnabled && (
+        <>
           <Folder
-            key={index}
+            key="folder-public-prompts"
             searchTerm={searchTerm}
-            currentFolder={folder}
-            handleDrop={handleDrop}
-            folderComponent={PromptFolders(folder)}
+            currentFolder={{
+              id: "folder-public-prompts",
+              name: t("Public prompts"),
+              type: "prompt"
+            }}
+            folderComponent={PromptFolders(filteredPublicPrompts, publicFolders, handleUpdatePublicPrompt, handleDeletePublicPrompt, null,
+              undefined, isAdminUser ? handleEditPublicFolder : undefined, isAdminUser ? handleDeletePublicFolder : undefined, undefined, false, false)}
+            handleAddItem={isAdminUser ? handleCreatePublicFolder : undefined}
           />
-        ))}
+          <Folder
+            key="folder-my-prompts"
+            searchTerm={searchTerm}
+            currentFolder={{
+              id: "folder-my-prompts",
+              name: t("My prompts"),
+              type: "prompt"
+            }}
+            folderComponent={PromptFolders(filteredPrompts, folders, handleUpdatePrompt, handleDeletePrompt, handleCreatePublicPrompt,
+              undefined, handleEditFolder, handleDeleteFolder, handleDrop)}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/components/Promptbar/components/PromptModal.tsx
+++ b/components/Promptbar/components/PromptModal.tsx
@@ -13,6 +13,7 @@ interface Props {
   prompt: Prompt;
   onClose: () => void;
   onUpdatePrompt: (prompt: Prompt) => void;
+  isEditable?: boolean;
 }
 
 export const PromptModal: FC<Props> = ({
@@ -20,6 +21,7 @@ export const PromptModal: FC<Props> = ({
   prompt,
   onClose,
   onUpdatePrompt,
+  isEditable = true
 }) => {
   const { t } = useTranslation('promptbar');
   const [name, setName] = useState(prompt.name);
@@ -35,6 +37,20 @@ export const PromptModal: FC<Props> = ({
       onClose();
     }
   };
+
+  const handleEditPrompt = (prompt: Prompt) => {
+    if (isEditable) {
+      const updatedPrompt = {
+        ...prompt,
+        name,
+        description,
+        content: content.trim(),
+      };
+
+      onUpdatePrompt(updatedPrompt);
+    }
+    onClose();
+  }
 
   useEffect(() => {
     nameInputRef.current?.focus();
@@ -62,6 +78,7 @@ export const PromptModal: FC<Props> = ({
         placeholder={t('A name for your prompt.') || ''}
         value={name}
         onChange={(e) => setName(e.target.value)}
+        isEditable={isEditable}
       />
       <div className="mt-6 text-sm font-bold text-black dark:text-neutral-200">
         {t('Description')}
@@ -73,6 +90,7 @@ export const PromptModal: FC<Props> = ({
         value={description}
         onChange={(e) => setDescription(e.target.value)}
         rows={3}
+        isEditable={isEditable}
       />
       <div className="mt-6 text-sm font-bold text-black dark:text-neutral-200">
         {t('Prompt')}
@@ -88,23 +106,14 @@ export const PromptModal: FC<Props> = ({
         value={content}
         onChange={(e) => setContent(e.target.value)}
         rows={10}
+        isEditable={isEditable}
       />
       <button
         type="button"
         className="w-full px-4 py-2 mt-6 border rounded-lg shadow border-neutral-500 text-neutral-900 hover:bg-neutral-100 focus:outline-none dark:border-neutral-800 dark:border-opacity-50 dark:bg-white dark:text-black dark:hover:bg-neutral-300"
-        onClick={() => {
-          const updatedPrompt = {
-            ...prompt,
-            name,
-            description,
-            content: content.trim(),
-          };
-
-          onUpdatePrompt(updatedPrompt);
-          onClose();
-        }}
+        onClick={isEditable ? () => handleEditPrompt(prompt) : onClose}
       >
-        {t('Save')}
+        {t(isEditable ? 'Save' : 'Close')}
       </button>
     </Dialog>
   );

--- a/components/Promptbar/components/PromptShareModal.tsx
+++ b/components/Promptbar/components/PromptShareModal.tsx
@@ -1,0 +1,89 @@
+import { FC, KeyboardEvent, useEffect, useRef, useState } from 'react';
+
+import { useTranslation } from 'next-i18next';
+
+import { Prompt } from '@/types/prompt';
+
+import { Dialog } from '@/components/Dialog/Dialog';
+import { FolderInterface } from '@/types/folder';
+import { v4 as uuidv4 } from 'uuid';
+
+interface Props {
+  open: boolean;
+  prompt: Prompt;
+  folders: FolderInterface[];
+  onClose: () => void;
+  onPublishPrompt: (prompt: Prompt) => void;
+}
+
+export const PromptShareModal: FC<Props> = ({
+  open,
+  prompt,
+  folders,
+  onClose,
+  onPublishPrompt,
+}) => {
+  const { t } = useTranslation('promptbar');
+  const [selectedFolderId, setSelectedFolder] = useState<string>(folders.length > 0 ? folders[0].id : "");
+
+  const handleEnter = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      onPublishPrompt({ ...prompt, folderId: selectedFolderId });
+      onClose();
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedFolder(e.target.value);
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      onKeyDown={handleEnter}
+    >
+      <div className="text-sm font-bold text-black dark:text-neutral-200">
+        {t('Select public folder')}
+      </div>
+      <div className="w-full rounded-lg border border-neutral-200 bg-transparent mt-4 pr-2 text-neutral-900 dark:border-neutral-600 dark:text-white">
+        <select
+          className="w-full bg-transparent p-2"
+          value={selectedFolderId}
+          onChange={handleChange}
+        >
+          {folders.map((folder) => (
+            <option
+              key={folder.id}
+              value={folder.id}
+              className="dark:bg-[#343541] dark:text-white"
+            >
+              {folder.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button
+        type="button"
+        className="w-full px-4 py-2 mt-6 border rounded-lg shadow border-neutral-500 text-neutral-900 hover:bg-neutral-100 focus:outline-none dark:border-neutral-800 dark:border-opacity-50 dark:bg-white dark:text-black dark:hover:bg-neutral-300"
+        disabled={!selectedFolderId}
+        onClick={() => {
+          const updatedPrompt = {
+            ...prompt,
+            id: uuidv4(),
+            folderId: selectedFolderId
+          };
+          onPublishPrompt(updatedPrompt);
+          onClose();
+        }}
+      >
+        {t('Publish')}
+      </button>
+    </Dialog>
+  );
+};

--- a/components/Promptbar/components/Prompts.tsx
+++ b/components/Promptbar/components/Prompts.tsx
@@ -6,13 +6,22 @@ import { PromptComponent } from './Prompt';
 
 interface Props {
   prompts: Prompt[];
+  handleUpdatePrompt(prompt: Prompt): void;
+  handleDeletePrompt(prompt: Prompt): void
+  handleCreatePublicPrompt(prompt: Prompt): void
+  isShareable?: boolean
 }
 
-export const Prompts: FC<Props> = ({ prompts }) => {
+export const Prompts: FC<Props> = ({ prompts, handleUpdatePrompt, handleDeletePrompt, handleCreatePublicPrompt, isShareable = false }) => {
   return (
     <div className="flex w-full flex-col gap-1">
       {prompts.map((prompt, index) => (
-        <PromptComponent key={index} prompt={prompt} />
+        <PromptComponent key={prompt.id} prompt={prompt}
+          handleUpdatePrompt={handleUpdatePrompt}
+          handleDeletePrompt={handleDeletePrompt}
+          handlePublishPrompt={handleCreatePublicPrompt}
+          isShareable={isShareable}
+        />
       ))}
     </div>
   );

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -2,8 +2,6 @@ import { IconFolderPlus, IconMistOff, IconPlus } from '@tabler/icons-react';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { FolderInterface } from '@/types/folder';
-
 import {
   CloseSidebarButton,
   OpenSidebarButton,
@@ -20,6 +18,8 @@ interface Props<T> {
   folderComponent: ReactNode;
   footerComponent?: ReactNode;
   searchTerm: string;
+  searchPlaceholder: string;
+  noItemsPlaceholder: string;
   handleSearchTerm: (searchTerm: string) => void;
   toggleOpen: () => void;
   handleCreateItem: () => void;
@@ -36,6 +36,8 @@ const Sidebar = <T,>({
   folderComponent,
   footerComponent,
   searchTerm,
+  searchPlaceholder,
+  noItemsPlaceholder,
   handleSearchTerm,
   toggleOpen,
   handleCreateItem,
@@ -82,7 +84,7 @@ const Sidebar = <T,>({
         </div>
         {(items?.length > 0 || searchTerm) && (
           <Search
-            placeholder={t('Search conversations...') || ''}
+            placeholder={searchPlaceholder || ''}
             searchTerm={searchTerm}
             onSearch={handleSearchTerm}
           />
@@ -107,7 +109,7 @@ const Sidebar = <T,>({
             <div className="mt-8 select-none text-center text-white opacity-50">
               <IconMistOff className="mx-auto mb-3" />
               <span className="text-[14px] leading-normal">
-                {t('No conversations.')}
+                {noItemsPlaceholder}
               </span>
             </div>
           )}

--- a/hooks/usePublicFolders.ts
+++ b/hooks/usePublicFolders.ts
@@ -1,0 +1,74 @@
+import { useCallback, useContext } from 'react';
+import { FolderInterface, FolderSchema, FolderType } from '@/types/folder';
+import HomeContext from '@/pages/api/home/home.context';
+import { trpc } from '@/utils/trpc';
+import { v4 as uuidv4 } from 'uuid';
+
+
+type PublicFoldersAction = {
+  update: (newState: FolderInterface) => Promise<FolderInterface[]>;
+  add: (name: string) => Promise<FolderInterface[]>;
+  remove: (folderId: string) => Promise<FolderInterface[]>;
+};
+
+export default function usePublicFolders(): [FolderInterface[], PublicFoldersAction] {
+  const publicPromptsList = trpc.publicPrompts.list.useQuery();
+  const folderUpdate = trpc.publicFolders.update.useMutation();
+  const folderRemove = trpc.publicFolders.remove.useMutation();
+  const {
+    state: { publicFolders, publicPrompts },
+    dispatch,
+  } = useContext(HomeContext);
+
+  const add = useCallback(
+    async (name: string) => {
+      const newFolder: FolderInterface = FolderSchema.parse({
+        id: uuidv4(),
+        name,
+        type: "prompt"
+      });
+      const newState = [newFolder, ...publicFolders];
+      await folderUpdate.mutateAsync(newFolder);
+      dispatch({ field: 'publicFolders', value: newState });
+      return newState;
+    },
+    [dispatch, folderUpdate, publicFolders],
+  );
+
+  const update = useCallback(
+    async (folder: FolderInterface) => {
+      const newState = publicFolders.map((f) => f.id === folder.id ? folder : f);
+      await folderUpdate.mutateAsync(folder);
+      dispatch({ field: 'publicFolders', value: newState });
+      return newState;
+    },
+    [dispatch, folderUpdate, publicFolders],
+  );
+
+  const remove = useCallback(
+    async (folderId: string) => {
+      const newState = publicFolders.filter((f) => f.id !== folderId);
+      await folderRemove.mutateAsync({ id: folderId });
+      dispatch({ field: 'publicFolders', value: newState });
+
+      const updatedPrompts = publicPromptsList.data;
+      dispatch({ field: 'publicPrompts', value: updatedPrompts });
+      return newState;
+    },
+    [
+      dispatch,
+      folderRemove,
+      publicFolders,
+      publicPrompts,
+    ],
+  );
+
+  return [
+    publicFolders,
+    {
+      add,
+      update,
+      remove,
+    },
+  ];
+}

--- a/hooks/usePublicPrompts.ts
+++ b/hooks/usePublicPrompts.ts
@@ -1,0 +1,65 @@
+import { useCallback, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { trpc } from '@/utils/trpc';
+
+import { Prompt } from '@/types/prompt';
+
+import HomeContext from '@/pages/api/home/home.context';
+
+type PublicPromptsAction = {
+  update: (newState: Prompt) => Promise<Prompt[]>;
+  add: (prompt: Prompt) => Promise<Prompt[]>;
+  remove: (prompt: Prompt) => Promise<Prompt[]>;
+};
+
+export default function usePublicPrompts(): [Prompt[], PublicPromptsAction] {
+  const { t: tErr } = useTranslation('error');
+  const {
+    state: { defaultModelId, publicPrompts },
+    dispatch,
+  } = useContext(HomeContext);
+  const promptsAdd = trpc.publicPrompts.add.useMutation();
+  const promptsUpdate = trpc.publicPrompts.update.useMutation();
+  const promptRemove = trpc.publicPrompts.remove.useMutation();
+
+  const add = useCallback(async (prompt: Prompt) => {
+    if (!defaultModelId) {
+      const err = tErr('No Default Model');
+      throw new Error(err);
+    }
+    await promptsAdd.mutateAsync(prompt);
+    const newState = [prompt, ...publicPrompts];
+    dispatch({ field: 'publicPrompts', value: newState });
+    return newState;
+  }, [defaultModelId, dispatch, publicPrompts, promptsAdd, tErr]);
+
+  const update = useCallback(
+    async (prompt: Prompt) => {
+      const newState = publicPrompts.map((f) => f.id === prompt.id ? prompt : f);
+      await promptsUpdate.mutateAsync(prompt);
+      dispatch({ field: 'publicPrompts', value: newState });
+      return newState;
+    },
+    [dispatch, publicPrompts, promptsUpdate],
+  );
+
+  const remove = useCallback(
+    async (prompt: Prompt) => {
+      const newState = publicPrompts.filter((f) => f.id !== prompt.id);
+      await promptRemove.mutateAsync({ id: prompt.id });
+      dispatch({ field: 'publicPrompts', value: newState });
+      return newState;
+    },
+    [dispatch, promptRemove, publicPrompts],
+  );
+
+  return [
+    publicPrompts,
+    {
+      add,
+      update,
+      remove,
+    },
+  ];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,6 +397,32 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@dqbd/tiktoken": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-1.0.7.tgz",
@@ -1311,6 +1337,38 @@
       "version": "10.23.0",
       "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.23.0.tgz",
       "integrity": "sha512-0CPfGZK3v3gfAL8ylV5vDJVBQtPp47EB4Vgx6WItSXmwYQlLC39ZC3gkZ4I5cGpQKl4l3QrNNeUvIcse4hlMxA=="
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "4.3.5",
@@ -2591,6 +2649,14 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -5698,6 +5764,14 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/markdown-table": {
       "version": "3.0.3",
@@ -9397,6 +9471,70 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -9731,6 +9869,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -10233,6 +10379,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/pages/api/home/home.state.tsx
+++ b/pages/api/home/home.state.tsx
@@ -17,10 +17,12 @@ export interface HomeInitialState {
   modelError: Error | null;
   models: OpenAIModel[];
   folders: FolderInterface[];
+  publicFolders: FolderInterface[];
   conversations: Conversation[];
   selectedConversation: Conversation | undefined;
   currentMessage: Message | undefined;
   prompts: Prompt[];
+  publicPrompts: Prompt[];
   showChatbar: boolean;
   showPromptbar: boolean;
   currentFolder: FolderInterface | undefined;
@@ -30,6 +32,7 @@ export interface HomeInitialState {
   serverSideApiKeyIsSet: boolean;
   serverSidePluginKeysSet: boolean;
   stopConversationRef: MutableRefObject<boolean>;
+  promptSharingEnabled: boolean
 }
 
 export const initialState: Partial<HomeInitialState> = {
@@ -45,10 +48,12 @@ export const initialState: Partial<HomeInitialState> = {
   modelError: null,
   models: [],
   folders: [],
+  publicFolders: [],
   conversations: [],
   selectedConversation: undefined,
   currentMessage: undefined,
   prompts: [],
+  publicPrompts: [],
   showPromptbar: true,
   showChatbar: true,
   currentFolder: undefined,
@@ -57,4 +62,5 @@ export const initialState: Partial<HomeInitialState> = {
   defaultModelId: undefined,
   serverSideApiKeyIsSet: false,
   serverSidePluginKeysSet: false,
+  promptSharingEnabled: false
 };

--- a/public/locales/es/promptbar.json
+++ b/public/locales/es/promptbar.json
@@ -8,5 +8,9 @@
   "A description for your prompt.": "Descripción de su prompt.",
   "Prompt": "Prompt",
   "Prompt content. Use {{}} to denote a variable. Ex: {{name}} is a {{adjective}} {{noun}}": "Contenido del prompt. Utilice {{}} para indicar una variable. Ej: {{nombre}} es un {{adjetivo}} {{nombre}}",
-  "Save": "Guardar"
+  "Public prompts": "Prompts públicas",
+  "My prompts": "Mis prompts",
+  "Save": "Guardar",
+  "Select public folder": "Selecciona una carpeta pública",
+  "Publish": "Publicar"
 }

--- a/server/context.ts
+++ b/server/context.ts
@@ -4,8 +4,9 @@ import { getUserHash } from '@/utils/server/auth';
 
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 
-import { inferAsyncReturnType } from '@trpc/server';
+import { TRPCError, inferAsyncReturnType } from '@trpc/server';
 import { CreateNextContextOptions } from '@trpc/server/adapters/next';
+import { UserRole } from '@/types/user';
 
 export async function createContext(opts: CreateNextContextOptions) {
   const session = await getServerSession(opts.req, opts.res, authOptions);
@@ -21,3 +22,15 @@ export async function createContext(opts: CreateNextContextOptions) {
   };
 }
 export type Context = inferAsyncReturnType<typeof createContext>;
+
+export async function validateAdminAccess(ctx: Context) {
+  if (!isAdminUser(ctx)) authError();
+}
+
+export function isAdminUser(ctx: Context): boolean {
+  return ctx.session?.user?.role === UserRole.ADMIN;
+}
+
+export async function authError() {
+  throw new TRPCError({ code: 'UNAUTHORIZED' });
+}

--- a/server/routers/_app.ts
+++ b/server/routers/_app.ts
@@ -1,15 +1,19 @@
 import { router } from '../trpc';
 import { conversations } from './conversations';
 import { folders } from './folders';
+import { publicFolders } from './publicFolders';
 import { models } from './models';
 import { prompts } from './prompts';
+import { publicPrompts } from './publicPrompts';
 import { settings } from './settings';
 
 export const appRouter = router({
   models,
   settings,
   prompts,
+  publicPrompts,
   folders,
+  publicFolders,
   conversations,
 });
 

--- a/server/routers/publicFolders.ts
+++ b/server/routers/publicFolders.ts
@@ -1,0 +1,29 @@
+import { PublicPromptsDb, getDb } from '@/utils/server/storage';
+
+import { FolderSchema } from '@/types/folder';
+
+import { procedure, router } from '../trpc';
+
+import { z } from 'zod';
+import { validateAdminAccess } from '../context';
+
+export const publicFolders = router({
+  list: procedure.query(async ({ ctx }) => {
+    const publicPromptsDb = new PublicPromptsDb(await getDb());
+    return await publicPromptsDb.getFolders();
+  }),
+  remove: procedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await validateAdminAccess(ctx);
+      const publicPromptsDb = new PublicPromptsDb(await getDb());
+      await publicPromptsDb.removeFolder(input.id);
+      return { success: true };
+    }),
+  update: procedure.input(FolderSchema).mutation(async ({ ctx, input }) => {
+    await validateAdminAccess(ctx);
+    const publicPromptsDb = new PublicPromptsDb(await getDb());
+    await publicPromptsDb.saveFolder(input);
+    return { success: true };
+  })
+});

--- a/server/routers/publicPrompts.ts
+++ b/server/routers/publicPrompts.ts
@@ -1,0 +1,45 @@
+import { PublicPromptsDb, UserDb, getDb } from '@/utils/server/storage';
+
+import { PromptSchema } from '@/types/prompt';
+
+import { procedure, router } from '../trpc';
+
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { Context, isAdminUser } from '../context';
+
+export const publicPrompts = router({
+  list: procedure.query(async ({ ctx }) => {
+    const publicPromptsDb = new PublicPromptsDb(await getDb());
+    return await publicPromptsDb.getPrompts();
+  }),
+  add: procedure.input(PromptSchema).mutation(async ({ ctx, input }) => {
+    const userDb = await UserDb.fromUserHash(ctx.userHash);
+    await userDb.publishPrompt(input);
+    return { success: true };
+  }),
+  remove: procedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const publicPromptsDb = new PublicPromptsDb(await getDb());
+      await validateOwnerOrAdminAccess(input.id, ctx);
+      await publicPromptsDb.removePrompt(input.id);
+      return { success: true };
+    }),
+  update: procedure.input(PromptSchema).mutation(async ({ ctx, input }) => {
+    const publicPromptsDb = new PublicPromptsDb(await getDb());
+    await validateOwnerOrAdminAccess(input.id, ctx);
+    await publicPromptsDb.savePrompt(input);
+    return { success: true };
+  })
+});
+
+async function validateOwnerOrAdminAccess(promptId: string, ctx: Context) {
+  if (!isAdminUser(ctx)) {
+    const publicPromptsDb = new PublicPromptsDb(await getDb());
+    const prompt = await publicPromptsDb.getPrompt(promptId);
+    if (!prompt || prompt.userId != ctx.userHash!) {
+      throw new TRPCError({ code: 'UNAUTHORIZED' });
+    }
+  }
+}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,7 @@
+import NextAuth, { DefaultSession } from "next-auth";
+import { User } from './user'
+declare module "next-auth" {
+  interface Session extends DefaultSession {
+    user?: User
+  }
+}

--- a/types/prompt.ts
+++ b/types/prompt.ts
@@ -9,6 +9,7 @@ export const PromptSchema = z.object({
   content: z.string(),
   model: OpenAIModelSchema,
   folderId: z.string().nullable(),
+  userId: z.string().optional(),
 });
 
 export const PromptSchemaArray = z.array(PromptSchema);

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,17 @@
+import * as z from 'zod';
+
+export enum UserRole {
+  ADMIN = "admin",
+  USER = "user"
+}
+
+export const UserSchema = z.object({
+  _id: z.string().optional(),
+  email: z.string(),
+  name: z.string().optional(),
+  role: z.nativeEnum(UserRole).optional(),
+});
+
+export const UserSchemaArray = z.array(UserSchema);
+
+export type User = z.infer<typeof UserSchema>;

--- a/utils/app/const.ts
+++ b/utils/app/const.ts
@@ -15,3 +15,5 @@ export const OPENAI_ORGANIZATION = process.env.OPENAI_ORGANIZATION || '';
 export const AZURE_DEPLOYMENT_ID_EMBEDDINGS = process.env.AZURE_DEPLOYMENT_ID_EMBEDDINGS || '';
 
 export const MONGODB_DB = process.env.MONGODB_DB || '';
+
+export const PROMPT_SHARING_ENABLED: boolean = process.env.PROMPT_SHARING_ENABLED === "true" || false;


### PR DESCRIPTION
This pull request implements new features to enable prompt sharing between users. 
- Public Prompts: This folder contains prompts that are visible to all users. Public prompts are created by publishing private ones, and their modifications are restricted to the owner and admins.
- My Prompts: This folder contains private prompts that are only accessible by the specific user.

![screenshot](https://github.com/dotneet/smart-chatbot-ui/assets/26725067/39450a1c-d734-47ae-a28c-5b6aca2ca976)

Changes Made:
- Created 'Public prompts' and 'My prompts' top-level folders in the prompt sidebar, and made the necessary UI component updates to accommodate them.
- Implemented user persistence in the database, with two predefined roles: 'user' and 'admin'.
- Modified and added relevant routes to handle public folders, prompts, and users.
- Added the ability to toggle the new functionality using the environment variable `PROMPT_SHARING_ENABLED`.
- Provided Spanish translations for the newly added elements.