### PR TITLE
Azure-AD fetch failed fix(?)

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -61,6 +61,14 @@ if (process.env.AZURE_AD_CLIENT_ID) {
       clientId: process.env.AZURE_AD_CLIENT_ID!,
       clientSecret: process.env.AZURE_AD_CLIENT_SECRET!,
       tenantId: process.env.AZURE_AD_TENANT_ID,
+      profile(profile) {
+        return {
+          id: profile.oid,
+          name: profile.name,
+          email: profile.email,
+          image: null
+        }
+      }
     }),
   );
 }


### PR DESCRIPTION
Hello everyone, by no means I am even close to being a developer, so even trying to wrap my head around this issue I spent few hours on it :)

I spotted a problem with out of the box Azure-AD configuration, after setting the required parameters:
- AZURE_AD_CLIENT_ID 
- AZURE_AD_TENANT_ID 
- AZURE_AD_CLIENT_SECRET 

It returned an error:
```
[next-auth][error][OAUTH_PARSE_PROFILE_ERROR] 
https://next-auth.js.org/errors#oauth_parse_profile_error fetch failed {
  error: {
    message: 'fetch failed',
    stack: 'TypeError: fetch failed\n' +
      '    at Object.fetch (node:internal/deps/undici/undici:11457:11)\n' +
      '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
      '    at async Object.profile (/app/node_modules/next-auth/providers/azure-ad.js:27:24)\n' +
      '    at async getProfile (/app/node_modules/next-auth/core/lib/oauth/callback.js:162:21)\n' +
      '    at async oAuthCallback (/app/node_modules/next-auth/core/lib/oauth/callback.js:136:27)\n' +
      '    at async Object.callback (/app/node_modules/next-auth/core/routes/callback.js:52:11)\n' +
      '    at async AuthHandler (/app/node_modules/next-auth/core/index.js:208:28)\n' +
      '    at async NextAuthApiHandler (/app/node_modules/next-auth/next/index.js:22:19)\n' +
      '    at async NextAuth._args$ (/app/node_modules/next-auth/next/index.js:106:14)',
    name: 'TypeError'
  },
```

After digging around, it seems like next-auth is expecting image to be in the oauth response from Azure, however, it is not the case if you take a look at the debug return from the log:
```
  OAuthProfile: {
    aud: '<redacted>',
    iss: '<redacted>',
    iat: 1692795111,
    nbf: 1692795111,
    exp: 1692799011,
    email: '<redacted>',
    name: '<redacted>',
    oid: '<redacted>',
    preferred_username: '<redacted>',
    rh: '<redacted>',
    sub: '<redacted>',
    tid: '<redacted>',
    uti: '<redacted>',
    ver: '2.0'
}
```

However, if you look at the documentation, it does not say anywhere about profile needing to be in the code: https://next-auth.js.org/providers/azure-ad, so I imagine, this might not be the right place for the change.

So in essence, this change adds image: null. I probably got this horribly wrong for all the wrong, however, the error message is gone and it logs in using Azure-AD just fine (thanks to the new and shiny GPT toy giving me a hint).