### PR TITLE
Fix Unsupported locale in wikipedia plugin

### DIFF
--- a/agent/plugins/executor.ts
+++ b/agent/plugins/executor.ts
@@ -28,7 +28,7 @@ export const createContext = (
   verbose: boolean,
 ): TaskExecutionContext => {
   const headers = extractHeaders(request);
-  const locale = headers['accept-language']?.split(',')[0] || 'en';
+  const locale = headers['accept-language']?.split(',')[0]?.split('-')[0] || 'en';
   return {
     taskId,
     headers,


### PR DESCRIPTION
Should resolve #132
Problem is where locale getting passed is en-US, fr-FR, while we are checking for ALLOWED_LOCALES: const ALLOWED_LOCALES = [
  'en',
  'ja',
  'fr',
  'de',
  'es',
  'ru',
  'pt',
  'zh',
  'it',
  'ar',
  'pl',
  'uk',
];

So the option is to split "-" and take first part of the locale that matches the allowed list.