### PR TITLE
Bug Fix Pull Request: Updating folderId when the conversation folder is deleted

### DIFF
--- a/hooks/useFolders.ts
+++ b/hooks/useFolders.ts
@@ -93,7 +93,7 @@ export default function useFolders(): [FolderInterface[], FoldersAction] {
         }
         return c;
       });
-      await conversationUpdateAll.mutateAsync(targetConversations);
+      await conversationUpdateAll.mutateAsync(updatedConversations);
       dispatch({ field: 'conversations', value: updatedConversations });
 
       const updatedPrompts: Prompt[] = prompts.map((p) => {


### PR DESCRIPTION
### Description
This pull request addresses the following bug:

**Bug**: The `folderId` of a conversation is not updated when the `conversation` folder is deleted.

### Changes Made
In this pull request, I have made the necessary changes to ensure that the `folderId` of a conversation is updated correctly when the associated `conversation` folder is deleted. 