### PR TITLE
[bugfix] Support for Default Indexing Policy via indexes

### DIFF
--- a/server/trpc.ts
+++ b/server/trpc.ts
@@ -1,6 +1,13 @@
+import { UserDb } from '@/utils/server/storage';
 import type { Context } from './context';
 
 import { TRPCError, initTRPC } from '@trpc/server';
+
+// Initialize database indexes 
+console.debug('server/trpc', 'Initializing database indexes...');
+(async () => {
+  await UserDb.createIndexesIfNeeded();
+})()
 
 // Avoid exporting the entire t-object
 // since it's not very descriptive.
@@ -12,7 +19,7 @@ export const middleware = t.middleware;
 
 const secure = middleware(async ({ ctx, next }) => {
   if (!ctx.userHash) {
-    throw new TRPCError({ code: 'UNAUTHORIZED' });
+    throw new TRPCError({ code: 'UNAUTHORIZED', cause: 'Missing UserHash' });
   }
   return next({
     ctx: {


### PR DESCRIPTION
When leveraging MongoDB with a Default Indexing Policy enabled (such as Azure/CosmosDB) the configuration requires any `sort()` fields to have a corresponding index. Without indexes, all database calls (with the exception of default `_id` indexes) fail. These failures result in 500 errors for the prompts sidebar and a complete loss in prompt functionality.

This PR adds initialization for the database to create the indexes.