### PR TITLE
Removed sync call in saving llm cost

### DIFF
--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -92,7 +92,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       });
     }
     const completionTokenCount = encoding.encode(responseText).length;
-    await saveLlmUsage(userId, model.id, "chat", {
+    saveLlmUsage(userId, model.id, "chat", {
       prompt: tokenCount,
       completion: completionTokenCount,
       total: tokenCount + completionTokenCount


### PR DESCRIPTION
Hey. thanks for your work maintaining this repo!
More like a question, but since the change is so small I thought it'd be faster to just make a PR.
Is there a reason why the llm cost indexing should be synchronous? 
I didn't really need that feature so bad on my own use case, and it bothered me a little bit to have that await when serving responses.

Feel free to close this if the await is actually needed to have client synchronized :D